### PR TITLE
Implement domain fetching in CyberTemp provider instead of static domains

### DIFF
--- a/Core/communication/mail/providers/cybertemp.py
+++ b/Core/communication/mail/providers/cybertemp.py
@@ -11,6 +11,7 @@ class CybertempApi(MailApi):
     def __init__(self, api_key: str):
         super().__init__(api_key)
         self.api_key = api_key
+        self.domains = self.get_domains()
 
     def create_account(self, username: str, password: str) -> Optional[str]:
         
@@ -55,6 +56,24 @@ class CybertempApi(MailApi):
                 "html": msg.get("html", "")
             })
         return normalized
+
+    def get_domains(self, type: str = "discord") -> list:
+        try:
+            resp = requests.get(f"{self.BASE_URL}/getDomains?type={type}",
+                               headers=self.headers,
+                               timeout=10,
+                            )
+        except requests.RequestException as e:
+            raise RuntimeError(f"Network error fetching CyberTemp inbox: {e}")
+
+        if not resp.ok:
+            raise RuntimeError(
+                f"CyberTemp API returned {resp.status_code}: {resp.text}"
+            )
+
+        data = resp.json()
+        return data
+    
 
     def delete_mailbox(self, email: str) -> bool:
         try:


### PR DESCRIPTION
This pull request enhances the `CybertempApi` mail provider by introducing a method to fetch available domains from the CyberTemp API and initializing these domains during object construction. The main focus is on improving how domain information is retrieved and managed.

**Domain Management Enhancements:**

* Added a `get_domains` method to `CybertempApi` that fetches available domains from the CyberTemp API, handling network errors and unsuccessful responses robustly.
* Modified the `__init__` method of `CybertempApi` to call `get_domains` during initialization and store the result in `self.domains`.Added a method to fetch domains from the CyberTemp API and initialized it in the constructor.